### PR TITLE
Added increased fuel consumption function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.45.0] - 2020-12-04
+### Added
+- Added fuel consumption function that increase the consumption rates of select vehicles
+
 ## [1.44.0] - 2020-11-20
 ### Added
 - Heal players when rearming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [1.45.0] - 2020-12-04
+## [1.45.0] - 2020-12-02
 ### Added
-- Added fuel consumption function that increase the consumption rates of select vehicles
+- Added a fuel consumption function that can be used to increase the consumption rates of selected vehicles
 
 ## [1.44.0] - 2020-11-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ See the [Zeus Guide](https://docs.google.com/document/d/1PFK__UcgmAJ1P3xBnJxeW2o
     missionNameSpace setVariable ["gearWeaponGrenadier", ["classnameOfWeapon", "classnameOfAmmunition", ["classnameOfAttachment"], "classnameOfSecondaryAmmunition"], true];
     missionNameSpace setVariable ["gearWeaponMarksman", ["classnameOfWeapon", "classnameOfAmmunition", ["classnameOfAttachment"]], true];
     missionNameSpace setVariable ["gearWeaponLauncher", ["classnameOfWeapon", "classnameOfAmmunition", ["classnameOfAttachment"]], true];
+
+#### Set Fuel consumption
+
+```sqf
+// When calling from the 3den Editor Object Init or
+// When using the init mid operation make sure the execution mode is set to Global:
+[_this, rateOfLeak] spawn ZO_fnc_fuelConsumption;
+
+// When calling from the debug console:
+[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;
+```

--- a/Zeus_yymmdd_Template.Stratis/description.ext
+++ b/Zeus_yymmdd_Template.Stratis/description.ext
@@ -62,6 +62,7 @@ class cfgFunctions {
 			class showFPS;
 			class sthudPatch;
 			class unitTracker;
+			class fuelConsumption;
 		};
 	};
 };

--- a/Zeus_yymmdd_Template.Stratis/functions/fn_fuelConsumption.sqf
+++ b/Zeus_yymmdd_Template.Stratis/functions/fn_fuelConsumption.sqf
@@ -10,18 +10,22 @@
 	1: NUMBER - the speed of the fuel leak in seconds, a number from 1 to 0; 1 is the entire fuel tank, 0 is nothing. (for 30 minutes use 0.00055 and 45 minutes use 0.00037)
 
 	Example:
-	When calling from  the vehicle init, mid mission or in the editor:
-	[_this, rateOfLeak] remoteExec ["ZO_fnc_fuelConsumption", 2];
-
+	When calling from the 3den Editor Object Init (when using the init mid operation make sure the exec mode is set to Global):
+	[_this, rateOfLeak] spawn ZO_fnc_fuelConsumption;
+	
 	When calling from the debug console:
-	[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;
-
+	[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;	
+	
 	Returns:
 	Nothing.
 */
 
+////////////////////////////////////////////////
+//               SUB-FUNCTIONS                //
+////////////////////////////////////////////////
 
 fn_fuelDecrease = {
+	// This function should only be executed on the machine where the vehicle is local and a player.
 	if (isServer) exitWith {};
 
 	_vehicle = _this select 0;
@@ -42,25 +46,24 @@ fn_fuelDecrease = {
 	};
 };
 
+////////////////////////////////////////////////
+//               FUNCTION LOOP                //
+////////////////////////////////////////////////
+// If function is not run on the server stop execution
+if (!isServer) exitwith{};
 
-if !isServer exitwith{};
-
-fn_startLoop = {
-	_vehicle = _this select 0;
-	_rate = _this select 1;
-	_vehicle setVariable ["zo_fuel_scriptRunning", false, true];
-	while {alive _vehicle} do {
-		// Pause until the vehicle gets transferred away from the server
-		waitUntil {!local _vehicle};
-		// owner = last driver of the vehicle
-		_owner = owner _vehicle;
-		if (_owner != 2) then {
-			_vehicle setVariable ["zo_fuel_scriptRunning", true, true];
-			[_vehicle, _rate] remoteExec ["fn_fuelDecrease", _owner];
-		};
-		waitUntil {isNull _vehicle or !(alive _vehicle ) or !(_vehicle getVariable ["zo_fuel_scriptRunning", false])};
-	};
-};
-_unit = _this select 0;
+_vehicle = _this select 0;
 _rate = _this select 1;
-[_unit, _rate] spawn fn_startLoop;
+
+// While loop to make sure that decrease function is run on correct client
+while {alive _vehicle} do {
+	// Pause until the vehicle gets transferred away from the server
+	waitUntil {!local _vehicle};
+	// owner = last driver of the vehicle
+	_owner = owner _vehicle;
+
+	_vehicle setVariable ["zo_fuel_scriptRunning", true, true];
+	[_vehicle, _rate] remoteExec ["fn_fuelDecrease", _owner];
+	// Loop when locality of vehicle is transferred between players
+	waitUntil {isNull _vehicle or !(alive _vehicle ) or !(_vehicle getVariable ["zo_fuel_scriptRunning", false])};
+};

--- a/Zeus_yymmdd_Template.Stratis/functions/fn_fuelConsumption.sqf
+++ b/Zeus_yymmdd_Template.Stratis/functions/fn_fuelConsumption.sqf
@@ -1,0 +1,62 @@
+/*
+	@file_name: Fuel_Consumption.sqf
+	@file_author: Kasteelharry & Gehock
+
+	Description:
+	Modifies the speed of which fuel is drained from the vehicle. Called from the vehicle init or debug console on server side.
+
+	Parameters:
+	0: OBJECT - the vehicle the code is called on; this if called from vehicle init or variable name if called from debug console
+	1: NUMBER - the speed of the fuel leak in seconds, a number from 1 to 0; 1 is the entire fuel tank, 0 is nothing. (for 30 minutes use 0.00055 and 45 minutes use 0.00037)
+
+	Example:
+	When calling from  the vehicle init, mid mission or in the editor:
+	nul=[_this, rateOfLeak] remoteExec ["ZO_fnc_fuelConsumption",2];
+
+	When calling from the debug console:
+	nul=[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;
+
+	Returns:
+	Nothing.
+*/
+
+
+fn_fuelDecr = {
+	_unit = _this select 0;
+	_unit setVariable ["running", true, true];
+	_rate = _this select 1;
+	if isServer exitWith{};
+	while {alive _unit} do {
+		waitUntil {(isEngineOn _unit)};
+		_fuel = fuel _unit;
+		_newFuel = (_fuel - _rate);
+		if (not local _unit) exitWith {_unit setVariable ["running", false, true];};
+		_unit setFuel _newFuel;
+		sleep 1;
+	};
+};
+
+
+if !isServer exitwith{};
+
+_unit = _this select 0;
+_rate = _this select 1;
+
+fn_startLoop = {
+	
+	_unit = _this select 0;
+	_rate = _this select 1;
+	_unit setVariable ["running", false, true];
+	_owner = owner _unit;
+	while {alive _unit} do {
+		waitUntil {not local _unit};
+		_owner = owner _unit;
+		if (_owner != 2) then {
+			_unit setVariable ["running", true, true];
+			[_unit, _rate] remoteExec ["fn_fuelDecr", _owner];
+		};
+		waitUntil { isNull _unit or !(alive _unit) or !(_unit getVariable ["running", false])};
+	};
+
+};
+[_unit, _rate] spawn fn_startLoop;

--- a/Zeus_yymmdd_Template.Stratis/functions/fn_fuelConsumption.sqf
+++ b/Zeus_yymmdd_Template.Stratis/functions/fn_fuelConsumption.sqf
@@ -6,16 +6,17 @@
 	Modifies the speed of which fuel is drained from the vehicle. Called from the vehicle init or debug console on server side.
 
 	Parameters:
-	0: OBJECT - the vehicle the code is called on; this if called from vehicle init or variable name if called from debug console
+	0: OBJECT - the vehicle the code is called on; _this if called from vehicle init or variable name if called from debug console
 	1: NUMBER - the speed of the fuel leak in seconds, a number from 1 to 0; 1 is the entire fuel tank, 0 is nothing. (for 30 minutes use 0.00055 and 45 minutes use 0.00037)
 
 	Example:
-	When calling from the 3den Editor Object Init (when using the init mid operation make sure the exec mode is set to Global):
+	When calling from the 3den Editor Object Init or
+	When using the init mid operation make sure the execution mode is set to Global:
 	[_this, rateOfLeak] spawn ZO_fnc_fuelConsumption;
-	
+
 	When calling from the debug console:
-	[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;	
-	
+	[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;
+
 	Returns:
 	Nothing.
 */
@@ -32,12 +33,13 @@ fn_fuelDecrease = {
 	_rate = _this select 1;
 	_vehicle setVariable ["zo_fuel_scriptRunning", true, true];
 
+	// Loop on client side while the vehicle is local to that machine
 	while {alive _vehicle} do {
 		waitUntil {isEngineOn _vehicle};
 		_fuel = fuel _vehicle;
 		_newFuel = (_fuel - _rate);
 		// Vehicle locality changed because another player got in the driver's seat
-		// -> transferring execution to them
+		// -> break loop and let server transfer execution to that machine
 		if (!local _vehicle) exitWith {
 			_vehicle setVariable ["zo_fuel_scriptRunning", false, true];
 		};
@@ -59,10 +61,11 @@ _rate = _this select 1;
 while {alive _vehicle} do {
 	// Pause until the vehicle gets transferred away from the server
 	waitUntil {!local _vehicle};
-	// owner = last driver of the vehicle
+	// owner = last driver of the vehicle or person that spawned it in
 	_owner = owner _vehicle;
 
 	_vehicle setVariable ["zo_fuel_scriptRunning", true, true];
+	// Start the main fuel decrease loop on the machine where the vehicle is local
 	[_vehicle, _rate] remoteExec ["fn_fuelDecrease", _owner];
 	// Loop when locality of vehicle is transferred between players
 	waitUntil {isNull _vehicle or !(alive _vehicle ) or !(_vehicle getVariable ["zo_fuel_scriptRunning", false])};


### PR DESCRIPTION
Description of the function:
	@file_name: Fuel_Consumption.sqf
	@file_author: Kasteelharry & Gehock

	Description:
	Modifies the speed of which fuel is drained from the vehicle. Called from the vehicle init or debug console on server side.

	Parameters:
	0: OBJECT - the vehicle the code is called on; this if called from vehicle init or variable name if called from debug console
	1: NUMBER - the speed of the fuel leak in seconds, a number from 1 to 0; 1 is the entire fuel tank, 0 is nothing. 
        (for 30 minutes use 0.00055 and 45 minutes use 0.00037)

	Example:
	When calling from  the vehicle init, mid mission or in the editor:
	nul=[_this, rateOfLeak] remoteExec ["ZO_fnc_fuelConsumption",2];

	When calling from the debug console:
	nul=[nameOfVehicle, rateOfLeak] spawn ZO_fnc_fuelConsumption;

	Returns:
	Nothing.